### PR TITLE
strip blank columns

### DIFF
--- a/gsheetsdb/convert.py
+++ b/gsheetsdb/convert.py
@@ -45,8 +45,9 @@ def convert_rows(cols, rows):
     for row in rows:
         values = []
         for i, col in enumerate(row['c']):
-            converter = converters[cols[i]['type']]
-            values.append(converter(col['v']) if col else None)
+            if i < len(cols):
+                converter = converters[cols[i]['type']]
+                values.append(converter(col['v']) if col else None)
         results.append(Row(*values))
 
     return results

--- a/gsheetsdb/query.py
+++ b/gsheetsdb/query.py
@@ -134,6 +134,10 @@ def execute(query, headers=0, credentials=None):
         if alias is not None:
             col['label'] = alias
 
+    # remove columns with no label/name
+    cols = [col for col in cols if col['label']]
+    payload['table']['cols'] = cols
+
     description = get_description_from_payload(payload)
 
     # convert rows to proper type (datetime, eg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ prompt_toolkit==2.0.4
 SQLAlchemy==1.2.11
 six==1.11.0
 requests==2.20.0
-moz_sql_parser==2.18.18240
+moz_sql_parser==3.32.20026


### PR DESCRIPTION
Sometimes google returns blank columns (ie `''`) in the results. This is most likely caused by edits to the columns at some point. Most programs assume that database column names are not blank so often `select * from ...` queries fail. This PR removes any blanks columns, and the associated row data, from the final results and description.   